### PR TITLE
[Provider][Netskope]:  v1.7.0 hotfix - Updated the pull retry mechanism and added recovery for interrupted data streams 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-__pycache__
+__pycache__/
 *.pyc

--- a/netskope_provider/CHANGELOG.md
+++ b/netskope_provider/CHANGELOG.md
@@ -1,6 +1,12 @@
-# 1.5.4-hotfix
+# 1.7.0-hotfix (Requires minimum Cloud Exchange version 6.0.0)
+## Changed
+- Updated the pull retry mechanism with a unified in-pull exponential backoff engine, replacing the legacy @retry decorator for more reliable handling of transient failures. Retries are now strictly bounded by pull windows (or 1 hour for historical pulls).
+- Added recovery for interrupted data streams (including automatic Dataexport resend support) while immediately failing only on authentication/permission errors (401/403).
+
+# 1.6.0
 ## Fixed
-- Updated historical pulling to process last batch.
+- Updated the historical pull logic to ensure that valid events within the requested time range from the last batch are processed.
+- Updated handling for pulling alerts/events from stored checkpoint.
 
 # 1.5.3
 ## Changed

--- a/netskope_provider/main.py
+++ b/netskope_provider/main.py
@@ -572,7 +572,11 @@ class NetskopeProviderPlugin(PluginBase):
             log_prefix=self.log_prefix,
             compress_historical_data=compress_historical_data,
         )
-        if not override_subtypes:
+        # An explicit empty list means the caller selected no sub-types -> pull nothing.
+        # Only None (the maintenance/live pull) means "no override -> tenant-wide union".
+        # `not override_subtypes` conflated [] with None and bled other plugins' sub-types
+        # into a historical pull that had selected nothing for this data type.
+        if override_subtypes is None:
             sub_type_config_mapping, latest_checked = (
                 get_sub_type_config_mapping(self.name, data_type)
             )
@@ -588,7 +592,8 @@ class NetskopeProviderPlugin(PluginBase):
             should_apply_expo_backoff,
             should_exec_lifecycle,
         ) in client.create_job():
-            if not override_subtypes:
+            # See note above: an explicit empty list must not fall back to the union.
+            if override_subtypes is None:
                 sub_type_config_mapping, latest_checked = (
                     get_sub_type_config_mapping(
                         self.name,

--- a/netskope_provider/manifest.json
+++ b/netskope_provider/manifest.json
@@ -8,7 +8,7 @@
         "webtx"
     ],
     "netskope": true,
-    "version": "1.5.4-hotfix",
+    "version": "1.6.0-hotfix",
     "module": "Tenant",
     "minimum_version": "6.0.0",
     "description": "This plugin is required to configure Netskope Tenant in Cloud Exchange. The Netskope Tenant will be used by the Netskope plugins to fetch the required data for each module.",

--- a/netskope_provider/utils/constants.py
+++ b/netskope_provider/utils/constants.py
@@ -36,8 +36,7 @@ from netskope_api.iterator.const import Const
 import os
 
 MODULE_NAME = "TENANT"
-PLUGIN_VERSION = "1.5.4-hotfix"
-MAXIMUM_CE_VERSION = "5.1.2"
+PLUGIN_VERSION = "1.6.0-hotfix"
 PLATFORM_NAME = "Netskope"
 MAX_API_CALLS = 4
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -67,11 +66,11 @@ EVENTS = {
     "application": Const.EVENT_TYPE_APPLICATION,
     "incident": Const.EVENT_TYPE_INCIDENT,
     "endpoint": "endpoint",
-    "clientstatus": "clientstatus"
+    "clientstatus": "clientstatus",
 }
 
 ITERATORS = {
-    key.lower(): list({x.strip() for x in value.split(',') if x.strip() != ""})
+    key.lower(): list({x.strip() for x in value.split(",") if x.strip() != ""})
     for key, value in os.environ.items()
     if key.lower().startswith("iterator_")
 }
@@ -88,20 +87,71 @@ RESULT = "result"
 TIMESTAMP_HWM = "timestamp_hwm"
 QUEUE_SIZE = 10
 DEFAULT_WAIT_TIME = 30
-EXPONENTIAL_WAIT_TIME = 180
 WAIT_TIME = "wait_time"
-DEFAULT_RETRY_COUNT = 3
-RETRY_COUNT_FOR_PULLING = os.environ.get("RETRY_COUNT_FOR_PULLING")
-if isinstance(RETRY_COUNT_FOR_PULLING, str) and RETRY_COUNT_FOR_PULLING.isnumeric():
-    RETRY_COUNT_FOR_PULLING = int(RETRY_COUNT_FOR_PULLING)
-    if RETRY_COUNT_FOR_PULLING < 1:
-        RETRY_COUNT_FOR_PULLING = DEFAULT_RETRY_COUNT
-else:
-    RETRY_COUNT_FOR_PULLING = DEFAULT_RETRY_COUNT
-STRING_FIELDS = ['dlp_incident_id', 'connection_id', 'app_session_id', 'dlp_parent_id', 'browser_session_id']
-DLP_INCIDENT_FORENSICS_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/forensics"
-DLP_INCIDENT_ORIGINAL_FILE_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/originalfile"
-DLP_INCIDENT_SUB_FILE_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/subfile"
+
+
+def _get_env_int(name, default, minimum=1):
+    """Read a positive integer override from the environment."""
+    value = os.environ.get(name)
+    if isinstance(value, str) and value.isnumeric() and int(value) >= minimum:
+        return int(value)
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Unified pull retry mechanism (see iterator_helper.PullRetryController).
+#
+# Every transient failure while pulling is retried in place with exponential
+# backoff: delays grow 30s -> 60s -> 120s -> 240s -> 480s (~15 min), then
+# stay flat at 15 min. Two bounds stop the retries:
+#   * maintenance pulling never retries past its scheduled pull window
+#     (MAINTENANCE_PULL_WINDOW_SECONDS after the task started);
+#   * any pull retries a single failure episode for at most
+#     BACKOFF_MAX_TOTAL seconds (this is the only bound for the one-shot
+#     historical pulls).
+#
+# Retry policy: retry EVERY HTTP error status except authentication (401)
+# and permission (403) failures, plus every network/stream/unexpected
+# exception. 401/403 are the only non-retryable statuses -- repeating the
+# request cannot succeed until the token or its scopes are fixed, and they
+# keep their banner/storage side effects. Every other 4xx and 5xx (including
+# 400/404 and 501/505) is retried within the bounds above; a request that
+# truly cannot succeed simply exhausts the episode budget and reports an
+# actionable failure.
+# ---------------------------------------------------------------------------
+NON_RETRYABLE_HTTP_STATUS_CODES = {401, 403}
+RETRYABLE_HTTP_STATUS_CODES = (
+    set(range(400, 600)) - NON_RETRYABLE_HTTP_STATUS_CODES
+)
+BACKOFF_INITIAL_DELAY = _get_env_int("PULL_BACKOFF_INITIAL_DELAY", 30)
+BACKOFF_FACTOR = 2
+BACKOFF_MAX_DELAY = _get_env_int("PULL_BACKOFF_MAX_DELAY", 900)
+# Upper bound of a single failure episode; the only bound for historical.
+BACKOFF_MAX_TOTAL = _get_env_int("PULL_BACKOFF_MAX_TOTAL", 3600)
+BACKOFF_JITTER_RATIO = 0.1
+BACKOFF_SLEEP_TICK = 30
+# Scheduled length of one maintenance pull cycle: load() stops pulling and
+# pull() stops retrying once this much time has passed since the cycle
+# started. The env override exists for testing only.
+MAINTENANCE_PULL_WINDOW_SECONDS = _get_env_int(
+    "PULL_MAINTENANCE_WINDOW_SECONDS", 3600
+)
+STRING_FIELDS = [
+    "dlp_incident_id",
+    "connection_id",
+    "app_session_id",
+    "dlp_parent_id",
+    "browser_session_id",
+]
+DLP_INCIDENT_FORENSICS_ENDPOINT = (
+    "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/forensics"
+)
+DLP_INCIDENT_ORIGINAL_FILE_ENDPOINT = (
+    "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/originalfile"
+)
+DLP_INCIDENT_SUB_FILE_ENDPOINT = (
+    "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/subfile"
+)
 # Rate limit remaining
 RATELIMIT_REMAINING = "ratelimit-remaining"
 # Rate limit RESET value is in seconds

--- a/netskope_provider/utils/iterator_api_helper.py
+++ b/netskope_provider/utils/iterator_api_helper.py
@@ -38,8 +38,6 @@ import traceback
 import time
 from typing import Dict, Union
 from requests.exceptions import ReadTimeout
-from netskope.common.api import __version__ as CE_VERSION
-from packaging import version
 
 import requests
 from netskope.common.utils import add_user_agent
@@ -47,14 +45,14 @@ from .constants import (
     PLATFORM_NAME,
     MODULE_NAME,
     MAX_API_CALLS,
-    MAXIMUM_CE_VERSION,
     DEFAULT_WAIT_TIME,
     RATELIMIT_RESET,
     RATELIMIT_REMAINING,
-    CLIENT_STATUS_ITERATOR_NAME
+    CLIENT_STATUS_ITERATOR_NAME,
 )
 
 from netskope.common.utils.plugin_provider_helper import PluginProviderHelper
+
 plugin_provider_helper = PluginProviderHelper()
 
 
@@ -78,11 +76,7 @@ class NetskopePluginHelper(object):
     """
 
     def __init__(
-        self,
-        logger,
-        log_prefix: str,
-        plugin_name: str,
-        plugin_version: str
+        self, logger, log_prefix: str, plugin_name: str, plugin_version: str
     ):
         """Netskope Provider Plugin Helper initializer.
 
@@ -96,33 +90,6 @@ class NetskopePluginHelper(object):
         self.logger = logger
         self.plugin_name = plugin_name
         self.plugin_version = plugin_version
-        self.resolution_support = version.parse(CE_VERSION) > version.parse(
-            MAXIMUM_CE_VERSION
-        )
-        self.is_ce_version_greater_than_512 = self.resolution_support
-        # Patch logger methods to handle resolution parameter compatibility
-        self._patch_logger_methods()
-
-    def _patch_logger_methods(self):
-        """patch logger methods to handle resolution parameter
-        compatibility."""
-        # Store original methods
-        original_error = self.logger.error
-
-        def patched_error(
-            message=None, details=None, resolution=None, **kwargs
-        ):
-            """Patched error method that handles resolution compatibility."""
-            log_kwargs = {"message": message}
-            if details:
-                log_kwargs["details"] = details
-            if resolution and self.resolution_support:
-                log_kwargs["resolution"] = resolution
-            log_kwargs.update(kwargs)
-            return original_error(**log_kwargs)
-
-        # Replace logger methods with patched versions
-        self.logger.error = patched_error
 
     def _add_user_agent(self, headers: Union[Dict, None] = None) -> Dict:
         """Add User-Agent in the headers for third-party requests.
@@ -160,7 +127,7 @@ class NetskopePluginHelper(object):
         is_handle_error_required=True,
         is_validation=False,
         regenerate_auth_token=True,
-        handle_rate_limit=False
+        handle_rate_limit=False,
     ):
         """API Helper to perform API request on ThirdParty platform \
         and captures all the possible errors for requests.
@@ -381,7 +348,7 @@ class NetskopePluginHelper(object):
     def honor_rate_limiting(self, headers):
         """
         Identify the response headers carrying the rate limiting value.
-        If the rate limit remaining for this endpoint is 0 then wait for 
+        If the rate limit remaining for this endpoint is 0 then wait for
             the rate limit reset time before sending the response to the client.
         """
         try:
@@ -518,7 +485,7 @@ class NetskopePluginHelper(object):
             else:
                 return
         elif status_code == 204:
-            return {}   
+            return {}
         elif (
             status_code == 400
             and "Only one iterator is allowed per event type. Please use the existing iterator"
@@ -607,7 +574,7 @@ class NetskopePluginHelper(object):
                 details=f"API response: {api_resp}",
             )
             raise NetskopeProviderPluginException(err_msg)
-        
+
     def update_storage(self, tenant_name, iterator_name):
         """
         Insert or Update Client Status iterator in storage.
@@ -620,10 +587,8 @@ class NetskopePluginHelper(object):
         """
         # self.storage["client_status_iterator"] = iterator_name
         update_set = {"client_status_iterator": iterator_name}
-        plugin_provider_helper.update_tenant_storage(
-            tenant_name, update_set
-        )
-    
+        plugin_provider_helper.update_tenant_storage(tenant_name, update_set)
+
     def create_iterator(
         self,
         tenant_url,
@@ -631,7 +596,7 @@ class NetskopePluginHelper(object):
         headers,
         iterator_name,
         proxies=None,
-        is_validation=False
+        is_validation=False,
     ):
         """
         Create Client Status iterator.
@@ -651,8 +616,7 @@ class NetskopePluginHelper(object):
             f"{tenant_url}/api/v2/events/dataexport/iterator/{iterator_name}"
         )
         logger_msg = (
-            "Creating Client Status "
-            f"iterator with name {iterator_name}"
+            "Creating Client Status " f"iterator with name {iterator_name}"
         )
         params = {"eventtype": "clientstatus"}
         # Create New Iterator - first time plugin is saved or if existing iterator does not exists
@@ -667,7 +631,7 @@ class NetskopePluginHelper(object):
             is_validation=is_validation,
         )
         if resp.status_code == 202:
-            match = re.search(r'(netskope_ce[^\s,]+)', resp.text)
+            match = re.search(r"(netskope_ce[^\s,]+)", resp.text)
             if match:
                 iterator_name = match.group(1)
                 log_msg = (
@@ -675,9 +639,7 @@ class NetskopePluginHelper(object):
                     f"iterator with name {iterator_name}"
                 )
                 self.update_storage(tenant_configuration_name, iterator_name)
-                self.logger.info(
-                    f"{self.log_prefix}: {log_msg}"
-                )
+                self.logger.info(f"{self.log_prefix}: {log_msg}")
                 return iterator_name
             else:
                 error_msg = (
@@ -686,39 +648,34 @@ class NetskopePluginHelper(object):
                 )
                 self.logger.error(
                     f"{self.log_prefix}: {error_msg}",
-                    details=f"API Response: {resp.text}"
+                    details=f"API Response: {resp.text}",
                 )
                 raise NetskopeProviderPluginException(
                     f"{error_msg}, check logs for details."
                 )
         else:
-            self.handle_error(
-                resp,
-                logger_msg,
-                is_validation=is_validation
-            )
+            self.handle_error(resp, logger_msg, is_validation=is_validation)
+
     def check_iterator_status(
-        self,
-        tenant_hostname,
-        headers,
-        proxies=None,
-        tenant_storage=None
+        self, tenant_hostname, headers, proxies=None, tenant_storage=None
     ):
         """
         This function is used to check the status of the Client status iterator.
-        
+
         Parameters:
         tenant_hostname (str): The tenant hostname.
         headers (dict): The headers to be sent with the API call.
         proxies (dict): The proxy configuration in case of proxy enabled.
         tenant_storage (dict): The tenant configuration storage.
-        
+
         Returns:
         bool: True if the iterator is ready else False.
         """
-        client_status_storage = tenant_storage.get(
-            "client_status_iterator", ""
-        ) if tenant_storage else ""
+        client_status_storage = (
+            tenant_storage.get("client_status_iterator", "")
+            if tenant_storage
+            else ""
+        )
         if client_status_storage:
             # Check the iterator status
             iterator_name = client_status_storage
@@ -727,15 +684,12 @@ class NetskopePluginHelper(object):
                 tenant_url=tenant_hostname,
                 tenant_configuration_name=self.tenant_name,
                 headers=headers,
-                iterator_name=CLIENT_STATUS_ITERATOR_NAME
-            )        
+                iterator_name=CLIENT_STATUS_ITERATOR_NAME,
+            )
         logger_msg = (
-            "Checking status of iterator "
-            f"with name {iterator_name}"
+            "Checking status of iterator " f"with name {iterator_name}"
         )
-        iterator_status_endpoint = (
-            f"{tenant_hostname}/api/v2/events/dataexport/iterator/{iterator_name}"
-        )
+        iterator_status_endpoint = f"{tenant_hostname}/api/v2/events/dataexport/iterator/{iterator_name}"
         while True:
             resp = self.api_helper(
                 logger_msg=logger_msg,

--- a/netskope_provider/utils/iterator_helper.py
+++ b/netskope_provider/utils/iterator_helper.py
@@ -1,6 +1,8 @@
 """Pulling mechanism using iterator."""
+
 import threading
 import time
+import random
 import re
 import gzip
 import json
@@ -20,7 +22,10 @@ from celery.exceptions import SoftTimeLimitExceeded
 from netskope_api.iterator.const import Const
 from netskope_api.iterator.netskope_iterator import NetskopeIterator
 from . import constants as CONST
-from .iterator_api_helper import NetskopePluginHelper, NetskopeProviderPluginException
+from .iterator_api_helper import (
+    NetskopePluginHelper,
+    NetskopeProviderPluginException,
+)
 from netskope.common.api import __version__
 from netskope.common.utils import (
     Logger,
@@ -29,8 +34,10 @@ from netskope.common.utils import (
     Notifier,
     back_pressure,
 )
-from netskope.common.utils.decorator import retry
-from netskope.common.utils.exceptions import IncompleteTransactionError, ForbiddenError
+from netskope.common.utils.exceptions import (
+    IncompleteTransactionError,
+    ForbiddenError,
+)
 from netskope.common.utils.handle_exception import handle_status_code
 from netskope.common.utils.plugin_provider_helper import PluginProviderHelper
 
@@ -38,6 +45,136 @@ connector = DBConnector()
 logger = Logger()
 notifier = Notifier()
 plugin_provider_helper = PluginProviderHelper()
+
+
+class PullRetriesExhaustedError(Exception):
+    """Raised when the retry budget for a failure episode is spent.
+
+    A pull retries one failing batch for at most CONST.BACKOFF_MAX_TOTAL
+    seconds (default 1 hour, counted from the first failure). When that
+    budget runs out without a success, this error ends the pull so the
+    caller can report an actionable failure instead of retrying forever.
+    """
+
+    pass
+
+
+class PullWindowElapsedError(Exception):
+    """Raised when the maintenance pull window ends while retrying.
+
+    This signals a graceful stop, not a failure: the owning maintenance
+    pull task is scheduled for a fixed window
+    (CONST.MAINTENANCE_PULL_WINDOW_SECONDS), and retries must never
+    overrun it. The caller ends the cycle normally and the next scheduled
+    pull cycle takes over (with the 'resend' operation when a broken
+    batch is still owed).
+    """
+
+    pass
+
+
+class PullRetryController:
+    """Paces and bounds the retries of a single pull() call.
+
+    Every transient failure is retried with exponential backoff:
+    CONST.BACKOFF_INITIAL_DELAY seconds, doubling per attempt
+    (CONST.BACKOFF_FACTOR) up to CONST.BACKOFF_MAX_DELAY, with a
+    +/- CONST.BACKOFF_JITTER_RATIO jitter so parallel sub-type threads do
+    not retry in lockstep.
+
+    Two independent bounds decide when to stop retrying:
+
+    * The **pull window** (`window_deadline`) — the wall-clock moment the
+      owning maintenance pull task's window ends. A retry is never
+      scheduled past it, and when it is the reason to stop, the give-up
+      reason is ``WINDOW`` (graceful stop). ``None`` for historical pulls
+      and other callers without a fixed window.
+    * The **episode budget** — at most CONST.BACKOFF_MAX_TOTAL seconds of
+      retrying, counted from the first failure of the current episode.
+      When it is the reason to stop, the give-up reason is ``BUDGET``.
+
+    The controller only computes delays and sleeps; error classification
+    and logging stay with the caller.
+    """
+
+    WINDOW = "window"
+    BUDGET = "budget"
+
+    def __init__(self, window_deadline=None):
+        """Initialize for one pull() call.
+
+        Args:
+            window_deadline (float | None): epoch seconds at which the
+                owning pull window ends, or None when there is no window.
+        """
+        self.window_deadline = window_deadline
+        self.attempt = 0
+        self._episode_start = None
+
+    def window_elapsed(self):
+        """Return True when the pull window is already over."""
+        return (
+            self.window_deadline is not None
+            and time.time() >= self.window_deadline
+        )
+
+    def _give_up_deadline(self):
+        """Epoch seconds after which no further retry may be scheduled."""
+        deadline = self._episode_start + CONST.BACKOFF_MAX_TOTAL
+        if self.window_deadline is not None:
+            deadline = min(deadline, self.window_deadline)
+        return deadline
+
+    def give_up_reason(self):
+        """Return which bound stopped the retries (WINDOW or BUDGET)."""
+        if self.window_deadline is None:
+            return self.BUDGET
+        episode_start = (
+            self._episode_start
+            if self._episode_start is not None
+            else time.time()
+        )
+        budget_deadline = episode_start + CONST.BACKOFF_MAX_TOTAL
+        return (
+            self.WINDOW
+            if self.window_deadline <= budget_deadline
+            else self.BUDGET
+        )
+
+    def next_delay(self):
+        """Return the next backoff delay in seconds, or None to give up.
+
+        None means sleeping the computed delay would cross the pull window
+        or exceed the per-episode retry budget.
+        """
+        now = time.time()
+        if self._episode_start is None:
+            self._episode_start = now
+        delay = min(
+            CONST.BACKOFF_INITIAL_DELAY * (CONST.BACKOFF_FACTOR**self.attempt),
+            CONST.BACKOFF_MAX_DELAY,
+        )
+        jitter = delay * CONST.BACKOFF_JITTER_RATIO
+        delay = delay + random.uniform(-jitter, jitter)
+        if now + delay > self._give_up_deadline():
+            return None
+        self.attempt += 1
+        return delay
+
+    def sleep(self, delay):
+        """Sleep `delay` seconds in CONST.BACKOFF_SLEEP_TICK chunks.
+
+        Returns False when the give-up deadline passes mid-sleep so the
+        caller stops promptly instead of finishing a long wait.
+        """
+        slept = 0
+        while slept < delay:
+            tick = min(CONST.BACKOFF_SLEEP_TICK, delay - slept)
+            time.sleep(tick)
+            slept += tick
+            if time.time() > self._give_up_deadline():
+                return False
+        return True
 
 
 def convert_numpy_types(obj):
@@ -58,29 +195,29 @@ def parse_csv_response(df: pd.DataFrame):
     # Step 1: Group columns by root key
     column_groups = collections.defaultdict(list)
     for col in df.columns:
-        if '.' in col:
-            root = col.split('.')[0]
+        if "." in col:
+            root = col.split(".")[0]
             column_groups[root].append(col)
 
     # Step 2: Create a new dataframe column-wise
     result = pd.DataFrame()
 
     def parse_complex_obj(val):
-        if isinstance(val, str) and '|' in val:
-            parts = val.split('|')
-            if any('=' not in segment for segment in parts):
+        if isinstance(val, str) and "|" in val:
+            parts = val.split("|")
+            if any("=" not in segment for segment in parts):
                 return parts
             else:
                 result_dict = {}
                 for segment in parts:
-                    key, value = segment.split('=', 1)
+                    key, value = segment.split("=", 1)
                     result_dict[key] = value
                 return result_dict
         return val
 
     # Direct (non-nested) columns and check for list conversion
     for col in df.columns:
-        if '.' not in col:
+        if "." not in col:
             result[col] = df[col].apply(parse_complex_obj)
 
     # Nested columns
@@ -89,7 +226,7 @@ def parse_csv_response(df: pd.DataFrame):
         for i in range(len(df)):
             temp = {}
             for col in cols:
-                keys = col.split('.')[1:]  # exclude root
+                keys = col.split(".")[1:]  # exclude root
                 val = df.at[i, col]
 
                 # Convert comma-separated strings to list
@@ -130,9 +267,7 @@ class NetskopeIteratorBuilder(NetskopeIterator):
         self.tenant = tenant
         self.tenant_name = tenant.get("name") if tenant else ""
         tenant_config_parameters = tenant.get("parameters", {})
-        self.tenant_hostname = tenant_config_parameters.get(
-            "tenantName", ""
-        )
+        self.tenant_hostname = tenant_config_parameters.get("tenantName", "")
         iterator_name = iterator_name.replace(" ", "")
         proxy = {}
         if tenant.get("use_proxy"):
@@ -151,6 +286,19 @@ class NetskopeIteratorBuilder(NetskopeIterator):
         self.timestamp_hwm = None
         self.should_apply_expo_backoff = False
         self.log_prefix = log_prefix
+        # Unified retry mechanism state. Retries are disabled by default so
+        # direct callers (e.g. token validation) keep fail-fast behavior;
+        # load()/load_historical() enable them. Pacing and bounds live in a
+        # per-pull() PullRetryController.
+        self.retry_enabled = False
+        self.persist_pending_resend = False
+        # The iterator name becomes a MongoDB key in tenant storage.
+        self._storage_key = re.sub(r"[.$]", "_", iterator_name)
+        pending_map = (tenant.get("storage") or {}).get("pending_resend") or {}
+        self.pending_resend = bool(
+            isinstance(pending_map, dict)
+            and pending_map.get(self._storage_key)
+        )
         from netskope.common.utils import resolve_secret
 
         if headers is None:
@@ -160,7 +308,9 @@ class NetskopeIteratorBuilder(NetskopeIterator):
             resolve_secret(tenant_config_parameters.get("v2token"))
         )
         params = {
-            Const.NSKP_TOKEN: resolve_secret(tenant_config_parameters.get("v2token")),
+            Const.NSKP_TOKEN: resolve_secret(
+                tenant_config_parameters.get("v2token")
+            ),
             Const.NSKP_TENANT_HOSTNAME: tenant_config_parameters.get(
                 "tenantName"
             ).removeprefix("https://"),
@@ -194,9 +344,9 @@ class NetskopeIteratorBuilder(NetskopeIterator):
         Fetch client status data form the stored
         Client Status iterator.
         """
-        client_status_storage = self.tenant.get(
-            "storage", {}
-        ).get("client_status_iterator", "")
+        client_status_storage = self.tenant.get("storage", {}).get(
+            "client_status_iterator", ""
+        )
         if client_status_storage:
             # Check the iterator status
             iterator_name = client_status_storage
@@ -206,7 +356,7 @@ class NetskopeIteratorBuilder(NetskopeIterator):
                 tenant_configuration_name=self.tenant_name,
                 headers=self.headers,
                 iterator_name=CONST.CLIENT_STATUS_ITERATOR_NAME,
-                proxies=self.proxy
+                proxies=self.proxy,
             )
         client_status_csv_endpoint = CONST.CLIENT_STATUS_CSV.format(
             self.tenant_hostname, iterator_name
@@ -252,20 +402,162 @@ class NetskopeIteratorBuilder(NetskopeIterator):
         """Set epoch timestamp."""
         self.epoch = epoch
 
-    @retry(
-        times=CONST.RETRY_COUNT_FOR_PULLING,
-        exceptions=(
-            ConnectionError,
-            IncompleteTransactionError,
-            requests.exceptions.ConnectionError,
-        ),
-        sleep=CONST.DEFAULT_WAIT_TIME,
-    )
-    def pull(self, parse_response=True, return_schema_headers=False):
-        """Pull data from Netskope."""
+    def _next_operation(self):
+        """Name the Data Export operation _fetch() will use next.
+
+        Single source of truth shared by _fetch() and the retry log so the
+        logged operation never disagrees with the one actually issued:
+
+        * ``resend`` — a committed-200 body broke mid-stream, so the
+          server-side iterator has advanced past that batch and it must be
+          re-fetched (``next`` would skip it);
+        * ``download`` — (re)establish the first batch from the start epoch.
+          The epoch is cleared only after a successful fetch, so a failed
+          first pull is retried with ``download``, not ``next``;
+        * ``next`` — advance the cursor to the following batch.
+        """
+        if self.retry_enabled and self.pending_resend:
+            return "resend"
+        index_names = []
+        for sub_type_indexes in CONST.ITERATORS.values():
+            index_names.extend(sub_type_indexes)
+        if self.epoch and self.index_name not in index_names:
+            return "download"
+        return "next"
+
+    def _fetch(self):
+        """Fetch a batch using the appropriate iterator operation.
+
+        The operation is chosen by _next_operation(); see it for the rules.
+        """
+        operation = self._next_operation()
+        if operation == "resend":
+            return self.resend()
+        if operation == "download":
+            return self.download(self.epoch)
+        return self.next()
+
+    def _set_pending_resend(self, value):
+        """Track (and for maintenance pulls, persist) the pending resend flag.
+
+        Persistence guarantees the broken chunk is re-fetched with 'resend' on
+        the next pull cycle even if this cycle gives up retrying.
+        """
+        if self.pending_resend == value:
+            return
+        self.pending_resend = value
+        if not self.persist_pending_resend:
+            return
+        key = f"pending_resend.{self._storage_key}"
+        try:
+            if value:
+                plugin_provider_helper.update_tenant_storage(
+                    self.tenant_name, {key: True}
+                )
+            else:
+                plugin_provider_helper.update_tenant_storage(
+                    self.tenant_name, {}, {key: ""}
+                )
+        except Exception as e:
+            logger.error(
+                f"{self.log_prefix}: "
+                f"Error occurred while updating the pending resend state for "
+                f"{self.sub_type} {self.type} of tenant {self.tenant_name}. {e}",
+                details=traceback.format_exc(),
+            )
+
+    def _retry_or_give_up(self, retry_ctrl, error):
+        """Pace one retry of a transient pull failure.
+
+        Returns normally after sleeping the backoff delay (the caller then
+        retries). Raises instead of retrying when:
+
+        * retries are disabled on this iterator (fail-fast callers such as
+          token validation) -> the original error;
+        * the maintenance pull window is ending -> PullWindowElapsedError
+          (graceful stop, the next pull cycle takes over);
+        * the per-episode retry budget is spent -> PullRetriesExhaustedError.
+        """
+        if not self.retry_enabled:
+            raise error
+        delay = retry_ctrl.next_delay()
+        if delay is not None:
+            operation = self._next_operation()
+            logger.error(
+                f"{self.log_prefix}: "
+                f"Error occurred while pulling {self.sub_type} {self.type} "
+                f"for the tenant {self.tenant_name}. Retrying (attempt "
+                f"{retry_ctrl.attempt}) with operation '{operation}' in "
+                f"{round(delay)} seconds. Error: {error}",
+                details=traceback.format_exc(),
+            )
+            if retry_ctrl.sleep(delay):
+                return
+        if retry_ctrl.give_up_reason() == PullRetryController.WINDOW:
+            logger.error(
+                f"{self.log_prefix}: "
+                f"Stopping retries for {self.sub_type} {self.type} of tenant "
+                f"{self.tenant_name} after {retry_ctrl.attempt} retry "
+                f"attempt(s): the pull window is ending. Pulling will resume "
+                f"in the next pull cycle. Last error: {error}"
+            )
+            raise PullWindowElapsedError(
+                f"The pull window elapsed while retrying {self.sub_type} "
+                f"{self.type} for the tenant {self.tenant_name}. "
+                f"Last error: {error}"
+            )
+        logger.error(
+            f"{self.log_prefix}: "
+            f"Giving up retries for {self.sub_type} {self.type} of tenant "
+            f"{self.tenant_name} after {retry_ctrl.attempt} retry attempt(s): "
+            f"the retry budget ({CONST.BACKOFF_MAX_TOTAL} seconds) is "
+            f"exhausted. Last error: {error}"
+        )
+        raise PullRetriesExhaustedError(
+            f"Retries exhausted while pulling {self.sub_type} {self.type} "
+            f"for the tenant {self.tenant_name}. Last error: {error}"
+        )
+
+    def pull(
+        self,
+        parse_response=True,
+        return_schema_headers=False,
+        pull_start_time=None,
+    ):
+        """Pull one batch of data from Netskope.
+
+        Unified retry mechanism: every transient failure — stream breaks
+        (ChunkedEncodingError/ContentDecodingError), connection errors,
+        every HTTP error status except 401/403, and any unexpected error —
+        is retried in place with exponential backoff (see
+        PullRetryController). Only 401 (authentication) and 403 (permission)
+        are raised immediately, keeping their banner/storage side effects,
+        because repeating the same request cannot succeed until the token or
+        its scopes are fixed.
+
+        Args:
+            parse_response (bool): parse JSON responses into dicts.
+            return_schema_headers (bool): also return response headers
+                (CSV pulls).
+            pull_start_time (datetime): start of the owning maintenance
+                pull window. When provided, no retry is scheduled past
+                pull_start_time + CONST.MAINTENANCE_PULL_WINDOW_SECONDS;
+                if the window ends first, PullWindowElapsedError is raised
+                so the caller can end the cycle gracefully. Omit for
+                historical pulls (bounded by the retry budget only) and
+                for fail-fast callers.
+        """
         from netskope.common.utils.forbidden_notifier import (
             create_or_ack_forbidden_error_banner,
         )
+
+        window_deadline = None
+        if pull_start_time is not None:
+            window_deadline = (
+                pull_start_time.timestamp()
+                + CONST.MAINTENANCE_PULL_WINDOW_SECONDS
+            )
+        retry_ctrl = PullRetryController(window_deadline=window_deadline)
         content = {}
         while True:
             if not self.tenant:
@@ -275,23 +567,27 @@ class NetskopeIteratorBuilder(NetskopeIterator):
                     error_code="CE_1032",
                 )
                 return {"success": False}
-            index_names = []
-            for sub_type_indexes in CONST.ITERATORS.values():
-                index_names.extend(sub_type_indexes)
-            if self.epoch and self.index_name not in index_names:
-                data = self.download(self.epoch)
-            else:
-                data = self.next()
-            if self.return_response:
-                return data
-            uri = urlparse(data.url).path
+            if retry_ctrl.window_elapsed():
+                # The owning maintenance task has reached the end of its
+                # scheduled window; do not start another request against it.
+                raise PullWindowElapsedError(
+                    f"The pull window elapsed while pulling {self.sub_type} "
+                    f"{self.type} for the tenant {self.tenant_name}."
+                )
+            uri = ""
             try:
+                data = self._fetch()
+                if self.return_response:
+                    return data
+                uri = urlparse(data.url).path
                 if (
                     not data.content
                     and data.headers.get("Content-Type", "").lower()
                     != "text/csv"
                 ):
-                    raise IncompleteTransactionError("Received empty response.")
+                    raise IncompleteTransactionError(
+                        "Received empty response."
+                    )
                 content = handle_status_code(
                     data,
                     error_code="CE_1061",
@@ -304,33 +600,60 @@ class NetskopeIteratorBuilder(NetskopeIterator):
                     parse_response=parse_response,
                 )
             except requests.exceptions.HTTPError as e:
-                if e.response is not None and e.response.status_code in [409, 429]:
-                    logger.error(
-                        f"{self.log_prefix}: "
-                        f"Received status code {e.response.status_code} while pulling {self.sub_type} "
-                        f"{self.type} for the tenant {self.tenant_name}. "
-                        f"Performing retry for url {e.response.url}. "
-                        f"Retrying in {CONST.DEFAULT_WAIT_TIME} seconds."
-                    )
-                    time.sleep(CONST.DEFAULT_WAIT_TIME)
-                    continue
-                elif e.response is not None and e.response.status_code == 401:
+                status_code = (
+                    e.response.status_code if e.response is not None else None
+                )
+                if status_code == 401:
+                    # Authentication failures are never retried: pulling
+                    # cannot succeed until the token is fixed.
                     self.should_apply_expo_backoff = True
-                    update_set = {"is_v2_token_expired": True}
                     plugin_provider_helper.update_tenant_storage(
-                        self.tenant_name, update_set
+                        self.tenant_name, {"is_v2_token_expired": True}
                     )
                     create_or_ack_forbidden_error_banner()
-                raise IncompleteTransactionError(
-                    f"Received error while pulling "
-                    f"{self.sub_type} {self.type}. Error: {e}"
-                )
-            except (ConnectionError, IncompleteTransactionError) as e:
-                raise ConnectionError(
-                    f"Connection error occurred while pulling {self.sub_type} {self.type}. "
-                    f"Error: {e}"
-                )
+                    logger.error(
+                        f"{self.log_prefix}: "
+                        f"Received authentication error (401) while pulling "
+                        f"{self.sub_type} {self.type} from the tenant "
+                        f"{self.tenant_name}; Update "
+                        f"the V2 token to resume pulling. Error: {e}",
+                        error_code="CE_1061",
+                        details=traceback.format_exc(),
+                    )
+                    raise IncompleteTransactionError(
+                        f"Received error while pulling "
+                        f"{self.sub_type} {self.type}. Error: {e}"
+                    )
+                if (
+                    status_code is not None
+                    and status_code not in CONST.RETRYABLE_HTTP_STATUS_CODES
+                ):
+                    # The only non-retryable status reaching this handler is
+                    # 403 when it surfaces as an HTTPError (401 is handled
+                    # above; 403 is normally raised as ForbiddenError).
+                    # Everything else is retryable, so this repeats only
+                    # requests that cannot succeed until permissions are fixed.
+                    logger.error(
+                        f"{self.log_prefix}: "
+                        f"Received non-retryable status code {status_code} "
+                        f"while pulling {self.sub_type} {self.type} from the "
+                        f"tenant {self.tenant_name}; this is not retried. "
+                        f"Error: {e}",
+                        error_code="CE_1061",
+                        details=traceback.format_exc(),
+                    )
+                    raise IncompleteTransactionError(
+                        f"Received error while pulling "
+                        f"{self.sub_type} {self.type}. Error: {e}"
+                    )
+                # Retryable status (anything except 401/403): the server did
+                # not deliver this batch, so the iterator did not advance and
+                # the same operation is retried.
+                self._retry_or_give_up(retry_ctrl, e)
+                continue
             except ForbiddenError as e:
+                # 403 is never retried; record the forbidden endpoint so
+                # the platform can surface the missing permission.
                 self.should_apply_expo_backoff = True
                 update_set = {
                     f"forbidden_endpoints.{self.sub_type}": uri,
@@ -340,16 +663,44 @@ class NetskopeIteratorBuilder(NetskopeIterator):
                     self.tenant_name, update_set
                 )
                 create_or_ack_forbidden_error_banner()
-                raise e
-            except Exception as e:
                 logger.error(
                     f"{self.log_prefix}: "
-                    f"Error occurred while pulling {self.sub_type} {self.type} "
-                    f"for the tenant {self.tenant_name}. {e}",
+                    f"Received permission error (403 Forbidden) while "
+                    f"pulling {self.sub_type} {self.type} from the tenant "
+                    f"{self.tenant_name} for the endpoint {uri}; "
+                    f"Grant the missing V2 token scope to "
+                    f"resume pulling. Error: {e}",
+                    error_code="CE_1061",
                     details=traceback.format_exc(),
-                    error_code="CE_1112",
-                )  # TODO: Need to confirm error code
+                )
                 raise e
+            except (
+                requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ContentDecodingError,
+            ) as e:
+                # The response body broke mid-transfer. A chunked body is
+                # only produced after the server has committed a 200
+                # response, so the server-side iterator has advanced past
+                # this batch: recover with 'resend' (re-fetch the same
+                # batch); 'next' would silently skip it. The flag is
+                # persisted (maintenance) so the batch survives even a
+                # give-up and is re-fetched in the next pull cycle.
+                if self.retry_enabled:
+                    self._set_pending_resend(True)
+                self._retry_or_give_up(retry_ctrl, e)
+                continue
+            except SoftTimeLimitExceeded:
+                # Celery is terminating the owning task; never swallow or
+                # retry this — propagate immediately.
+                raise
+            except Exception as e:
+                # Anything else — connection errors, timeouts, empty
+                # responses, unexpected failures — is treated as transient
+                # and retried within the same bounds.
+                self._retry_or_give_up(retry_ctrl, e)
+                continue
+            if self.pending_resend:
+                self._set_pending_resend(False)
             self.epoch = None
 
             update_set = {"is_v2_token_expired": False}
@@ -357,26 +708,29 @@ class NetskopeIteratorBuilder(NetskopeIterator):
             new_document = plugin_provider_helper.update_tenant_storage(
                 self.tenant_name, update_set, update_unset, True
             )
-            new_forbidden_endpoints = new_document.get("storage", {}).get("forbidden_endpoints") if new_document else {}
-            current_forbidden_endpoints = self.tenant.get("storage", {}).get(
-                "forbidden_endpoints"
-            ) if self.tenant else {}
-            is_forbidden_value_changed = new_forbidden_endpoints != current_forbidden_endpoints
+            new_forbidden_endpoints = (
+                new_document.get("storage", {}).get("forbidden_endpoints")
+                if new_document
+                else {}
+            )
+            current_forbidden_endpoints = (
+                self.tenant.get("storage", {}).get("forbidden_endpoints")
+                if self.tenant
+                else {}
+            )
+            is_forbidden_value_changed = (
+                new_forbidden_endpoints != current_forbidden_endpoints
+            )
             if (
-                (
-                    self.tenant
-                    and self.tenant.get("storage", {}).get("is_v2_token_expired")
-                )
-                or is_forbidden_value_changed
-            ):
+                self.tenant
+                and self.tenant.get("storage", {}).get("is_v2_token_expired")
+            ) or is_forbidden_value_changed:
                 create_or_ack_forbidden_error_banner()
             if not return_schema_headers:
                 return content
             else:
                 headers = data.headers
-                if (
-                    headers.get("Content-Type", "").lower() == "text/csv"
-                ):
+                if headers.get("Content-Type", "").lower() == "text/csv":
                     return content, headers
                 else:
                     return content, None
@@ -492,7 +846,9 @@ class NetskopeClient:
                 [self.iterator_name % sub_type]
                 if self.pulling_type == NetskopeClient.HISTORICAL_PULLING
                 else (
-                    CONST.ITERATORS.get(f"iterator_{self.type.lower()}_{sub_type.lower().replace(' ', '_')}")
+                    CONST.ITERATORS.get(
+                        f"iterator_{self.type.lower()}_{sub_type.lower().replace(' ', '_')}"
+                    )
                     or [self.iterator_name % sub_type]
                 )
             )
@@ -503,15 +859,15 @@ class NetskopeClient:
     @sub_types.setter
     def sub_types(self, sub_types):
         """Spawn dedicated thread for pulling."""
-        iterator_subtype_indexes, iterator_indexes = self.get_indexes(sub_types)
+        iterator_subtype_indexes, iterator_indexes = self.get_indexes(
+            sub_types
+        )
         if set(iterator_indexes) == self.threads:
             self._sub_types = iterator_indexes
             return
         self._sub_types = iterator_indexes
         for sub_type, iterator_names in iterator_subtype_indexes.items():
-            if (
-                sub_type == CONST.EVENTS.get("clientstatus")
-            ):
+            if sub_type == CONST.EVENTS.get("clientstatus"):
                 if self.pulling_type == NetskopeClient.HISTORICAL_PULLING:
                     logger.debug(
                         f"{self.log_prefix}: "
@@ -520,11 +876,13 @@ class NetskopeClient:
                     )
                     continue
                 else:
-                    is_iterator_ready = self.netskope_api_plugin_helper.check_iterator_status(
-                        tenant_hostname=self.tenant_hostname,
-                        headers=self.headers,
-                        proxies=self.proxy,
-                        tenant_storage=self.tenant.get("storage", {})
+                    is_iterator_ready = (
+                        self.netskope_api_plugin_helper.check_iterator_status(
+                            tenant_hostname=self.tenant_hostname,
+                            headers=self.headers,
+                            proxies=self.proxy,
+                            tenant_storage=self.tenant.get("storage", {}),
+                        )
                     )
                     if not is_iterator_ready:
                         continue
@@ -533,7 +891,11 @@ class NetskopeClient:
                 if iterator_name not in self.threads:
                     self.threads.add(iterator_name)
                     thread_process = threading.Thread(
-                        target=self.get_target_function(), args=(sub_type, iterator_name, )
+                        target=self.get_target_function(),
+                        args=(
+                            sub_type,
+                            iterator_name,
+                        ),
                     )
                     thread_process.start()
                     self.running_thread += 1
@@ -564,7 +926,7 @@ class NetskopeClient:
                 f"{self.log_prefix}: "
                 f"Completed pull task for {datetime.fromtimestamp(start_time)} "
                 f"to {datetime.fromtimestamp(end_time)} time interval, "
-                f"Pulled {self.type} from {self.tenant_name} tenant."
+                f"pulled {self.type} from {self.tenant_name} tenant."
             )
         except SoftTimeLimitExceeded as ex:
             raise ex
@@ -604,15 +966,19 @@ class NetskopeClient:
         try:
             start_time = datetime.now()
             iterator = self.get_iterator(sub_type, iterator_name)
+            iterator.retry_enabled = True
+            iterator.persist_pending_resend = True
 
             tenant_dict_storage = self.tenant.get("storage", {})
-            if tenant_dict_storage.get(f"first_{self.type}_pull", {}).get(
-                f"first_{sub_type}_pull", True
+            first_pull_state = tenant_dict_storage.get(
+                f"first_{self.type}_pull", {}
+            )
+            first_subtype_pull = f"first_{sub_type}_pull"
+            if (
+                isinstance(first_pull_state, dict)
+                and first_subtype_pull not in first_pull_state
             ):
-                initial_pull = self.tenant.get("checkpoint")
-                if not initial_pull:
-                    initial_pull = datetime.now()
-
+                initial_pull = datetime.now()
                 initial_pull = initial_pull.replace(
                     minute=0, second=0, microsecond=0
                 ).strftime("%s")
@@ -636,8 +1002,10 @@ class NetskopeClient:
                     return {"success": False}
                 now = datetime.now()
                 time_delta = now - start_time
-                hours = time_delta.total_seconds() // 3600
-                if hours >= 1:
+                if (
+                    time_delta.total_seconds()
+                    >= CONST.MAINTENANCE_PULL_WINDOW_SECONDS
+                ):
                     return {"success": True}
 
                 if back_pressure.STOP_PULLING:
@@ -672,15 +1040,23 @@ class NetskopeClient:
                     return {"success": True}
 
                 self.pulling_started = True
+                # pull_start_time bounds in-pull retries to this thread's
+                # pull window: retries never overrun the window, and a
+                # window ending mid-retry raises PullWindowElapsedError
+                # (handled below as a graceful end of this cycle).
                 response, headers = iterator.pull(
-                    parse_response=False, return_schema_headers=True
+                    parse_response=False,
+                    return_schema_headers=True,
+                    pull_start_time=start_time,
                 )
                 if headers:  # data is in CSV format Client status + index name
                     schema_header = headers.get("schema_headers", "")
                     wait_time = CONST.DEFAULT_WAIT_TIME
                     if schema_header:
                         try:
-                            schema_header = json.loads(schema_header.replace("'", '"'))
+                            schema_header = json.loads(
+                                schema_header.replace("'", '"')
+                            )
                         except json.decoder.JSONDecodeError:
                             error_msg = (
                                 "Error occurred while fetching the schema headers. "
@@ -691,7 +1067,9 @@ class NetskopeClient:
                                 details=traceback.format_exc(),
                             )
                             return {"success": False}
-                        wait_time = schema_header.get("wait_time", CONST.DEFAULT_WAIT_TIME)
+                        wait_time = schema_header.get(
+                            "wait_time", CONST.DEFAULT_WAIT_TIME
+                        )
                         schema_headers = {
                             key.encode(): b"version," + value.encode()
                             for key, value in schema_header.items()
@@ -705,12 +1083,26 @@ class NetskopeClient:
                                 f"{self.tenant.get('name')} in CSV format using {iterator_name} index."
                             )
                             # Try enrichment if needed
-                            if sub_type == CONST.EVENTS.get("incident") and self.incident_enrichment:
+                            if (
+                                sub_type == CONST.EVENTS.get("incident")
+                                and self.incident_enrichment
+                            ):
                                 response_decoded = [
-                                    line.decode() if isinstance(line, bytes) else line for line in response if line
+                                    (
+                                        line.decode()
+                                        if isinstance(line, bytes)
+                                        else line
+                                    )
+                                    for line in response
+                                    if line
                                 ]
-                                enriched_batches = self._enrich_csv_incident_data(
-                                    response_decoded, sub_type, iterator_name, schema_headers=schema_headers
+                                enriched_batches = (
+                                    self._enrich_csv_incident_data(
+                                        response_decoded,
+                                        sub_type,
+                                        iterator_name,
+                                        schema_headers=schema_headers,
+                                    )
                                 )
                                 if enriched_batches:
                                     for batch in enriched_batches:
@@ -723,14 +1115,20 @@ class NetskopeClient:
                                                 header,
                                                 b"\n".join(
                                                     filter(
-                                                        lambda x: x.startswith(key),
-                                                        response
+                                                        lambda x: x.startswith(
+                                                            key
+                                                        ),
+                                                        response,
                                                     )
-                                                )
+                                                ),
                                             ]
                                         )
-                                        content = gzip.compress(batch, compresslevel=3)
-                                        self.message_queue.put((content, sub_type, False, True))
+                                        content = gzip.compress(
+                                            batch, compresslevel=3
+                                        )
+                                        self.message_queue.put(
+                                            (content, sub_type, False, True)
+                                        )
                             else:
                                 # Original logic for non-incident data
                                 for key, header in schema_headers.items():
@@ -739,14 +1137,20 @@ class NetskopeClient:
                                             header,
                                             b"\n".join(
                                                 filter(
-                                                    lambda x: x.startswith(key),
+                                                    lambda x: x.startswith(
+                                                        key
+                                                    ),
                                                     response,
                                                 )
                                             ),
                                         ]
                                     )
-                                    content = gzip.compress(batch, compresslevel=3)
-                                    self.message_queue.put((content, sub_type, False, True))
+                                    content = gzip.compress(
+                                        batch, compresslevel=3
+                                    )
+                                    self.message_queue.put(
+                                        (content, sub_type, False, True)
+                                    )
                         else:
                             logger.info(
                                 f"{self.log_prefix}: "
@@ -754,9 +1158,14 @@ class NetskopeClient:
                                 f"{self.tenant.get('name')} in CSV format using {iterator_name} index."
                             )
                     elif response:
-                        wait_time = headers.get("wait_time", CONST.DEFAULT_WAIT_TIME)
+                        wait_time = headers.get(
+                            "wait_time", CONST.DEFAULT_WAIT_TIME
+                        )
                         # Try enrichment if needed
-                        if sub_type == CONST.EVENTS.get("incident") and self.incident_enrichment:
+                        if (
+                            sub_type == CONST.EVENTS.get("incident")
+                            and self.incident_enrichment
+                        ):
                             enriched_batches = self._enrich_csv_incident_data(
                                 response, sub_type, iterator_name
                             )
@@ -765,13 +1174,17 @@ class NetskopeClient:
                                     self.message_queue.put(batch)
                             else:
                                 # Fallback to original logic
-                                content = gzip.compress(response, compresslevel=3)
+                                content = gzip.compress(
+                                    response, compresslevel=3
+                                )
                                 logger.info(
                                     f"{self.log_prefix}: "
                                     f"Pulled {len(response.splitlines())-1} {sub_type} {self.type}(s) for tenant "
                                     f"{self.tenant.get('name')} in CSV format using {iterator_name} index (enrichment failed)."
                                 )
-                                self.message_queue.put((content, sub_type, False, True))
+                                self.message_queue.put(
+                                    (content, sub_type, False, True)
+                                )
                         else:
                             # Original logic for non-incident data
                             content = gzip.compress(response, compresslevel=3)
@@ -780,7 +1193,9 @@ class NetskopeClient:
                                 f"Pulled {len(response.splitlines())-1} {sub_type} {self.type}(s) for tenant "
                                 f"{self.tenant.get('name')} in CSV format using {iterator_name} index."
                             )
-                            self.message_queue.put((content, sub_type, False, True))
+                            self.message_queue.put(
+                                (content, sub_type, False, True)
+                            )
                     else:
                         logger.info(
                             f"{self.log_prefix}: "
@@ -788,7 +1203,9 @@ class NetskopeClient:
                             f"{self.tenant.get('name')} in CSV format using {iterator_name} index."
                         )
                 else:  # data is in json
-                    number_of_alerts = len(re.findall(CONST.ID_PATTERN, response))
+                    number_of_alerts = len(
+                        re.findall(CONST.ID_PATTERN, response)
+                    )
                     ok_match = re.search(CONST.OK_PATTERN, response)
                     timestamp_hwm_match = re.search(
                         CONST.TIMESTAMP_HWM_PATTERN, response
@@ -797,7 +1214,9 @@ class NetskopeClient:
                         iterator.timestamp_hwm = int(
                             timestamp_hwm_match.group(1).decode()
                         )
-                    wait_time_match = re.search(CONST.WAIT_TIME_PATTERN, response)
+                    wait_time_match = re.search(
+                        CONST.WAIT_TIME_PATTERN, response
+                    )
                     if not response or (
                         ok_match and int(ok_match.group(1).decode()) != 1
                     ):
@@ -806,9 +1225,7 @@ class NetskopeClient:
                             f"Response: {response}"
                         )
                         notifier.error(message)
-                        logger.error(
-                            message=f"{self.log_prefix}: {message}"
-                        )
+                        logger.error(message=f"{self.log_prefix}: {message}")
                         return {"success": False}
                     pull_message = (
                         f", pulled data till {datetime.fromtimestamp(int(timestamp_hwm_match.group(1).decode()))}."
@@ -820,25 +1237,38 @@ class NetskopeClient:
                         f"Pulled {number_of_alerts} {sub_type} {self.type}(s) for tenant "
                         f"{self.tenant.get('name')} in JSON format using {iterator_name} index{pull_message}"
                     )
-                    if sub_type == CONST.EVENTS.get("incident") and self.incident_enrichment:
+                    if (
+                        sub_type == CONST.EVENTS.get("incident")
+                        and self.incident_enrichment
+                    ):
                         response = response.decode()
                         response = json.loads(response)
-                        response[CONST.RESULT] = self.enrich_incident_data(response.get(CONST.RESULT, []))
-                        response = json.dumps(response).encode('utf-8')
+                        response[CONST.RESULT] = self.enrich_incident_data(
+                            response.get(CONST.RESULT, [])
+                        )
+                        response = json.dumps(response).encode("utf-8")
                     content = gzip.compress(response, compresslevel=3)
                     self.message_queue.put(
-                        (
-                            content,
-                            sub_type,
-                            False,
-                            number_of_alerts != 0
-                        )
+                        (content, sub_type, False, number_of_alerts != 0)
                     )
                     wait_time = CONST.DEFAULT_WAIT_TIME
                     if wait_time_match:
                         wait_time = int(wait_time_match.group(1).decode())
                 self.update_pull_status(sub_type)
                 time.sleep(int(wait_time))
+        except PullWindowElapsedError:
+            # Graceful end of this maintenance cycle: the pull window
+            # elapsed while a failing batch was being retried. Any owed
+            # 'resend' is persisted, so the next scheduled pull cycle
+            # recovers the batch and continues.
+            logger.info(
+                f"{self.log_prefix}: "
+                f"The maintenance pull window elapsed while retrying "
+                f"{sub_type} {self.type}(s) for the tenant "
+                f"{self.tenant_name}; pulling will resume in the next "
+                f"pull cycle."
+            )
+            return {"success": True}
         except Exception as ex:
             logger.error(
                 f"{self.log_prefix}: "
@@ -850,58 +1280,36 @@ class NetskopeClient:
         finally:
             should_apply_expo_backoff = False
             if iterator and iterator.should_apply_expo_backoff:
-                should_apply_expo_backoff = should_apply_expo_backoff or iterator.should_apply_expo_backoff
+                should_apply_expo_backoff = (
+                    should_apply_expo_backoff
+                    or iterator.should_apply_expo_backoff
+                )
 
             self.should_exit.set()
             with self.lock:
                 self.running_thread -= 1
-                self.message_queue.put(([], sub_type, should_apply_expo_backoff, True))
+                self.message_queue.put(
+                    ([], sub_type, should_apply_expo_backoff, True)
+                )
 
-    def filter_data(self, data: List) -> List:
+    def filter_data(self, data: List, sub_type: str) -> List:
         """Return filtered data within the time range [start_time, end_time]."""
         filtered = []
-        filtered_out_before = 0
         filtered_out_after = 0
-        timestamp_before = []
-        timestamp_after = []
 
         for record in data:
             timestamp = record.get("timestamp", 0)
             if timestamp <= self.end_time:
                 filtered.append(record)
-            if timestamp < self.start_time:
-                filtered_out_before += 1
-                timestamp_before.append(timestamp)
             if timestamp > self.end_time:
                 filtered_out_after += 1
-                timestamp_after.append(timestamp)
         # Log only if records were filtered out (helps debugging without noise)
-        if filtered_out_before > 0 or filtered_out_after > 0:
-            filter_details = (
-                f"Filter Summary:\n"
-                f"  - Input Records: {len(data)}\n"
-                f"  - Accepted Records: {len(filtered)}\n"
-                f"  - Before Start Time (before start_time {self.start_time}): {filtered_out_before}\n"
-                f"  - After End Time (after end_time {self.end_time}): {filtered_out_after}\n"
-                f"  - Start Time: {datetime.fromtimestamp(self.start_time)}\n"
-                f"  - End Time: {datetime.fromtimestamp(self.end_time)}"
+        if filtered_out_after > 0:
+            logger.info(
+                f"{self.log_prefix}: Filtered out {filtered_out_after} {sub_type} {self.type}(s)"
+                f" as they were outside the historical pull time range."
             )
-            logger.debug(
-                message=(
-                    f"{self.log_prefix}: [HISTORICAL_FILTER_DATA_LOG] Input: {len(data)}, Accepted: {len(filtered)}, "
-                    f"Filtered (before start_time): {filtered_out_before}, Filtered (after end_time): {filtered_out_after}"
-                ),
-                details=filter_details
-            )
-            logger.debug(
-                message=f"{self.log_prefix}: [HISTORICAL_FILTER_DATA_LOG] Timestamp before:",
-                details=str(timestamp_before)
-            )
-            logger.debug(
-                message=f"{self.log_prefix}: [HISTORICAL_FILTER_DATA_LOG] Timestamp after:",
-                details=str(timestamp_after)
-            )
-        
+
         return filtered
 
     def load_historical(self, sub_type: str, iterator_name: str):
@@ -911,34 +1319,33 @@ class NetskopeClient:
             f"  - Sub Type: {sub_type}\n"
             f"  - Data Type: {self.type}\n"
             f"  - Iterator Name: {iterator_name}\n"
-            f"  - Tenant: {self.tenant_name}\n"
             f"  - Start Time: {self.start_time} ({datetime.fromtimestamp(self.start_time)})\n"
             f"  - End Time: {self.end_time} ({datetime.fromtimestamp(self.end_time)})\n"
-            f"  - Duration: {(self.end_time - self.start_time) / 3600:.2f} hours\n"
-            f"  - Source Config: {self.source_configuration}\n"
-            f"  - Destination Config: {self.destination_configuration}\n"
-            f"  - Business Rule: {self.business_rule}"
         )
         logger.debug(
             message=(
-                f"{self.log_prefix}: [HISTORICAL_PULL_START] Starting historical pull for {sub_type} {self.type}. "
-                f"Time range: {datetime.fromtimestamp(self.start_time)} to {datetime.fromtimestamp(self.end_time)} "
-                f"(epoch: {self.start_time} - {self.end_time}), Iterator: {iterator_name}"
+                f"{self.log_prefix}: Starting historical pull for {sub_type} {self.type}(s)."
             ),
-            details=start_details
+            details=start_details,
         )
-        iterator = self.get_iterator(sub_type, iterator_name, is_historical=True)
+        iterator = self.get_iterator(
+            sub_type, iterator_name, is_historical=True
+        )
+        # Historical pulling is a one-shot task with no pull window, so no
+        # pull_start_time is passed to pull(): each failure episode is
+        # retried for at most BACKOFF_MAX_TOTAL seconds (default 1 hour)
+        # before the pull gives up with PullRetriesExhaustedError. The
+        # resend flag is not persisted because every historical run
+        # repositions the iterator via set_timestamp().
+        iterator.retry_enabled = True
         # registered = connector.collection(Collections.ITERATOR).find_one(
         #     {"name": self.iterator_name % sub_type}
         # )
 
         # if not registered:
         iterator.set_timestamp(self.start_time)
-        
+
         # Track total records for summary
-        total_raw_records = 0
-        total_filtered_records = 0
-        iteration_count = 0
 
         pull_time = None
         try:
@@ -967,9 +1374,9 @@ class NetskopeClient:
                     time.sleep(NetskopeClient.BACK_PRESSURE_WAIT_TIME)
                     continue
 
-                self.tenant = connector.collection(Collections.NETSKOPE_TENANTS).find_one(
-                    {"name": self.tenant.get("name")}
-                )
+                self.tenant = connector.collection(
+                    Collections.NETSKOPE_TENANTS
+                ).find_one({"name": self.tenant.get("name")})
                 if not self.tenant:
                     logger.error(
                         f"{self.log_prefix}: "
@@ -979,7 +1386,6 @@ class NetskopeClient:
                     return {"success": False}
 
                 response = iterator.pull()
-                iteration_count += 1
 
                 if not response or response.get("ok") != 1:
                     logger.error(
@@ -992,71 +1398,37 @@ class NetskopeClient:
 
                 current_hwm = response.get(CONST.TIMESTAMP_HWM, 0)
                 current_result = response.get(CONST.RESULT, [])
-                total_raw_records += len(current_result)
-                
+
                 # Check if we should terminate AFTER processing this batch
                 should_terminate = current_hwm > self.end_time or (
-                    pull_time == current_hwm
-                    and not len(current_result)
+                    pull_time == current_hwm and not len(current_result)
                 )
-                
+
                 # FIX: Even if HWM > end_time, we should still process the current batch
                 # because it may contain records that are within the time range
                 if should_terminate and current_result:
                     # Process the final batch before terminating
-                    filtered_data = self.filter_data(current_result)
-                    total_filtered_records += len(filtered_data)
-                    final_batch_details = (
-                        f"Final Batch Processing Details:\n"
-                        f"  - Iteration: {iteration_count}\n"
-                        f"  - Current HWM: {current_hwm} ({datetime.fromtimestamp(current_hwm)})\n"
-                        f"  - End Time: {self.end_time} ({datetime.fromtimestamp(self.end_time)})\n"
-                        f"  - HWM > End Time: {current_hwm > self.end_time}\n"
-                        f"  - Raw Records in Batch: {len(current_result)}\n"
-                        f"  - Filtered Records in Batch: {len(filtered_data)}\n"
-                        f"  - Running Total Raw: {total_raw_records}\n"
-                        f"  - Running Total Filtered: {total_filtered_records}"
-                    )
-                    logger.debug(
-                        message=(
-                            f"{self.log_prefix}: [HISTORICAL_FINAL_BATCH] Processing final batch. "
-                            f"HWM: {current_hwm} ({datetime.fromtimestamp(current_hwm)}), "
-                            f"Raw: {len(current_result)}, Filtered: {len(filtered_data)}"
-                        ),
-                        details=final_batch_details
-                    )
+                    filtered_data = self.filter_data(current_result, sub_type)
                     if filtered_data:
                         # If sub type is incident and forensics enabled, enrich
-                        if sub_type == CONST.EVENTS.get("incident") and self.incident_enrichment:
-                            filtered_data = self.enrich_incident_data(filtered_data)
+                        if (
+                            sub_type == CONST.EVENTS.get("incident")
+                            and self.incident_enrichment
+                        ):
+                            filtered_data = self.enrich_incident_data(
+                                filtered_data
+                            )
                         if self.compress_historical_data:
-                            filtered_data = gzip.compress(json.dumps({CONST.RESULT: filtered_data}).encode('utf-8'), compresslevel=3)
-                        self.message_queue.put((filtered_data, sub_type, False, True))
-                    
-                    complete_details = (
-                        f"Historical Pull Summary:\n"
-                        f"  - Sub Type: {sub_type}\n"
-                        f"  - Data Type: {self.type}\n"
-                        f"  - Tenant: {self.tenant.get('name')}\n"
-                        f"  - Iterator: {iterator_name}\n"
-                        f"  - Start Time: {self.start_time} ({datetime.fromtimestamp(self.start_time)})\n"
-                        f"  - End Time: {self.end_time} ({datetime.fromtimestamp(self.end_time)})\n"
-                        f"  - Final HWM: {current_hwm} ({datetime.fromtimestamp(current_hwm)})\n"
-                        f"  - Total Iterations: {iteration_count}\n"
-                        f"  - Total Raw Records: {total_raw_records}\n"
-                        f"  - Total Filtered Records: {total_filtered_records}\n"
-                        f"  - Records Filtered Out: {total_raw_records - total_filtered_records}\n"
-                        f"  - Termination Reason: HWM exceeded end_time (final batch processed)"
-                    )
-                    logger.debug(
-                        message=(
-                            f"{self.log_prefix}: [HISTORICAL_PULL_COMPLETE] "
-                            f"Historical pulling of {sub_type} {self.type}(s) for tenant {self.tenant.get('name')} "
-                            f"completed. Time window: {datetime.fromtimestamp(self.start_time)} to {datetime.fromtimestamp(self.end_time)}. "
-                            f"Total iterations: {iteration_count}, Raw records: {total_raw_records}, Filtered records: {total_filtered_records}"
-                        ),
-                        details=complete_details
-                    )
+                            filtered_data = gzip.compress(
+                                json.dumps(
+                                    {CONST.RESULT: filtered_data}
+                                ).encode("utf-8"),
+                                compresslevel=3,
+                            )
+                        self.message_queue.put(
+                            (filtered_data, sub_type, False, True)
+                        )
+
                     logger.info(
                         f"{self.log_prefix}: "
                         f"Historical pulling of {sub_type} {self.type}(s) for tenant {self.tenant.get('name')} "
@@ -1064,40 +1436,23 @@ class NetskopeClient:
                         f"to {datetime.fromtimestamp(self.end_time)}."
                     )
                     return {"success": True}
-                
+
                 # If we should terminate but no data in current batch, just return
                 if should_terminate:
-                    complete_details_no_data = (
-                        f"Historical Pull Summary:\n"
-                        f"  - Sub Type: {sub_type}\n"
-                        f"  - Data Type: {self.type}\n"
-                        f"  - Tenant: {self.tenant.get('name')}\n"
-                        f"  - Iterator: {iterator_name}\n"
-                        f"  - Start Time: {self.start_time} ({datetime.fromtimestamp(self.start_time)})\n"
-                        f"  - End Time: {self.end_time} ({datetime.fromtimestamp(self.end_time)})\n"
-                        f"  - Final HWM: {current_hwm} ({datetime.fromtimestamp(current_hwm)})\n"
-                        f"  - Total Iterations: {iteration_count}\n"
-                        f"  - Total Raw Records: {total_raw_records}\n"
-                        f"  - Total Filtered Records: {total_filtered_records}\n"
-                        f"  - Records Filtered Out: {total_raw_records - total_filtered_records}\n"
-                        f"  - Termination Reason: HWM exceeded end_time or no more data"
-                    )
-                    logger.debug(
-                        message=(
-                            f"{self.log_prefix}: [HISTORICAL_PULL_COMPLETE] "
-                            f"Historical pulling of {sub_type} {self.type}(s) for tenant {self.tenant.get('name')} "
-                            f"completed. Time window: {datetime.fromtimestamp(self.start_time)} to {datetime.fromtimestamp(self.end_time)}. "
-                            f"Total iterations: {iteration_count}, Raw records: {total_raw_records}, Filtered records: {total_filtered_records}"
-                        ),
-                        details=complete_details_no_data
+                    logger.info(
+                        f"{self.log_prefix}: "
+                        f"Historical pulling of {sub_type} {self.type}(s) for tenant {self.tenant.get('name')} "
+                        f"is done for time window {datetime.fromtimestamp(self.start_time)} "
+                        f"to {datetime.fromtimestamp(self.end_time)}."
                     )
                     return {"success": True}
 
-                filtered_data = self.filter_data(current_result)
-                total_filtered_records += len(filtered_data)
+                filtered_data = self.filter_data(current_result, sub_type)
                 pull_time = response.get(CONST.TIMESTAMP_HWM, 0)
                 pull_message = (
-                    f" until {datetime.fromtimestamp(pull_time)} " if pull_time else " "
+                    f" until {datetime.fromtimestamp(pull_time)} "
+                    if pull_time
+                    else " "
                 )
                 if (
                     self.source_configuration
@@ -1119,10 +1474,18 @@ class NetskopeClient:
                         f"for configuration {self.source_configuration}."
                     )
                 # If sub type is incident and forensics enabled, enrich
-                if sub_type == CONST.EVENTS.get("incident") and self.incident_enrichment:
+                if (
+                    sub_type == CONST.EVENTS.get("incident")
+                    and self.incident_enrichment
+                ):
                     filtered_data = self.enrich_incident_data(filtered_data)
                 if self.compress_historical_data and filtered_data:
-                    filtered_data = gzip.compress(json.dumps({CONST.RESULT: filtered_data}).encode('utf-8'), compresslevel=3)
+                    filtered_data = gzip.compress(
+                        json.dumps({CONST.RESULT: filtered_data}).encode(
+                            "utf-8"
+                        ),
+                        compresslevel=3,
+                    )
                 self.message_queue.put((filtered_data, sub_type, False, True))
                 # if not registered:
                 #     connector.collection(Collections.ITERATOR).insert_one(
@@ -1131,8 +1494,22 @@ class NetskopeClient:
                 #     registered = True
                 wait_time = CONST.DEFAULT_WAIT_TIME
                 if len(response.get(CONST.RESULT, [])) != 0:
-                    wait_time = response.get(CONST.WAIT_TIME, CONST.DEFAULT_WAIT_TIME)
+                    wait_time = response.get(
+                        CONST.WAIT_TIME, CONST.DEFAULT_WAIT_TIME
+                    )
                 time.sleep(wait_time)
+        except PullRetriesExhaustedError as ex:
+            logger.error(
+                f"{self.log_prefix}: "
+                f"Retries exhausted while pulling {sub_type} {self.type}(s) for "
+                f"the tenant {self.tenant_name}. The historical pull for the "
+                f"time window {datetime.fromtimestamp(self.start_time)} to "
+                f"{datetime.fromtimestamp(self.end_time)} is incomplete for "
+                f"{sub_type} {self.type}(s) and needs to be triggered again. "
+                f"{ex}",
+                error_code="CE_1111",
+                details=traceback.format_exc(),
+            )
         except Exception as ex:
             logger.error(
                 f"{self.log_prefix}: "
@@ -1164,7 +1541,14 @@ class NetskopeClient:
     #         alerts = tenant.alert_types
     #     return alerts, latest_checked
 
-    def _enrich_csv_incident_data(self, response_data, sub_type, iterator_name, schema_headers=None, header=None):
+    def _enrich_csv_incident_data(
+        self,
+        response_data,
+        sub_type,
+        iterator_name,
+        schema_headers=None,
+        header=None,
+    ):
         """
         Enrich CSV incident data with forensics information.
         And return compressed json.
@@ -1186,8 +1570,16 @@ class NetskopeClient:
             if schema_headers:
                 # Handle versioned CSV format
                 for key_bytes, header_bytes in schema_headers.items():
-                    key = key_bytes.decode() if isinstance(key_bytes, bytes) else key_bytes
-                    header = header_bytes.decode() if isinstance(header_bytes, bytes) else header_bytes
+                    key = (
+                        key_bytes.decode()
+                        if isinstance(key_bytes, bytes)
+                        else key_bytes
+                    )
+                    header = (
+                        header_bytes.decode()
+                        if isinstance(header_bytes, bytes)
+                        else header_bytes
+                    )
                     # Filter lines for the current version and decode from bytes to string
                     response_data = [
                         line.decode() if isinstance(line, bytes) else line
@@ -1204,25 +1596,31 @@ class NetskopeClient:
                         continue
 
                     # Get column names from the original schema_header dict
-                    columns = [
-                        h.strip() for h in header.split(',')
-                    ]
+                    columns = [h.strip() for h in header.split(",")]
                     # Read CSV with version column
-                    df = pd.read_csv(StringIO(csv_data), header=None, names=columns)
+                    df = pd.read_csv(
+                        StringIO(csv_data), header=None, names=columns
+                    )
 
                     # Convert to dict format and enrich
                     # incidents_list = df.to_dict('records')
                     incidents_list = parse_csv_response(df)
 
-                    enriched_incidents = self.enrich_incident_data(incidents_list)
+                    enriched_incidents = self.enrich_incident_data(
+                        incidents_list
+                    )
 
                     if enriched_incidents:
                         content = gzip.compress(
-                            json.dumps({CONST.RESULT: enriched_incidents}).encode('utf-8'),
-                            compresslevel=3
+                            json.dumps(
+                                {CONST.RESULT: enriched_incidents}
+                            ).encode("utf-8"),
+                            compresslevel=3,
                         )
 
-                        enriched_batches.append((content, sub_type, False, True))
+                        enriched_batches.append(
+                            (content, sub_type, False, True)
+                        )
 
                         logger.info(
                             f"{self.log_prefix}: "
@@ -1231,24 +1629,40 @@ class NetskopeClient:
                         )
             else:
                 # Handle simple CSV format
-                response_lines = response_data.splitlines() if isinstance(response_data, str) else response_data.decode().splitlines()
-                if len(response_lines) > 1:  # Must have at least header + 1 data row
+                response_lines = (
+                    response_data.splitlines()
+                    if isinstance(response_data, str)
+                    else response_data.decode().splitlines()
+                )
+                if (
+                    len(response_lines) > 1
+                ):  # Must have at least header + 1 data row
                     # Read CSV data using pandas
-                    csv_string = response_data if isinstance(response_data, str) else response_data.decode()
-                    df = pd.read_csv(StringIO(csv_string), sep=',')
+                    csv_string = (
+                        response_data
+                        if isinstance(response_data, str)
+                        else response_data.decode()
+                    )
+                    df = pd.read_csv(StringIO(csv_string), sep=",")
 
                     # Convert to dict format and enrich
                     # incidents_list = df.to_dict('records')
                     incidents_list = parse_csv_response(df)
-                    enriched_incidents = self.enrich_incident_data(incidents_list)
+                    enriched_incidents = self.enrich_incident_data(
+                        incidents_list
+                    )
 
                     if enriched_incidents:
                         content = gzip.compress(
-                            json.dumps({CONST.RESULT: enriched_incidents}).encode('utf-8'),
-                            compresslevel=3
+                            json.dumps(
+                                {CONST.RESULT: enriched_incidents}
+                            ).encode("utf-8"),
+                            compresslevel=3,
                         )
 
-                        enriched_batches.append((content, sub_type, False, True))
+                        enriched_batches.append(
+                            (content, sub_type, False, True)
+                        )
 
                         logger.info(
                             f"{self.log_prefix}: "
@@ -1285,26 +1699,25 @@ class NetskopeClient:
             "Enriching incident data with forensics "
             f"data for incident id: {incident_id}."
         )
-        logger_msg = (
-            f"fetching forensics data for incident {incident_id}"
-        )
+        logger_msg = f"fetching forensics data for incident {incident_id}"
         try:
             forensics_data = self.netskope_api_plugin_helper.api_helper(
                 logger_msg=logger_msg,
                 url=CONST.DLP_INCIDENT_FORENSICS_ENDPOINT.format(
-                    base_url=self.tenant_hostname,
-                    dlp_incident_id=incident_id
+                    base_url=self.tenant_hostname, dlp_incident_id=incident_id
                 ),
                 method="GET",
                 headers=self.headers,
                 proxies=self.proxy,
                 is_validation=False,
-                handle_rate_limit=True
+                handle_rate_limit=True,
             )
 
             # Extract the different components we want to return
             result = {
-                "forensics_content": forensics_data.get("data", {}).get("content", ""),
+                "forensics_content": forensics_data.get("data", {}).get(
+                    "content", ""
+                ),
             }
 
             # Parse the meta field if it exists
@@ -1312,8 +1725,12 @@ class NetskopeClient:
             if meta_data:
                 try:
                     parsed_meta = json.loads(meta_data)
-                    result["forensics_metadata_content"] = parsed_meta.get("metadata_content", "")
-                    result["forensics_dlp_match_info"] = parsed_meta.get("dlp_match_info", [])
+                    result["forensics_metadata_content"] = parsed_meta.get(
+                        "metadata_content", ""
+                    )
+                    result["forensics_dlp_match_info"] = parsed_meta.get(
+                        "dlp_match_info", []
+                    )
                 except json.JSONDecodeError:
                     logger.error(
                         f"{self.log_prefix}: Error parsing meta data JSON for incident {incident_id}",
@@ -1341,7 +1758,10 @@ class NetskopeClient:
                     ),
                 )
                 raise ForbiddenError(error_message) from err
-            if "400" in error_message and "http client error" in error_message.lower():
+            if (
+                "400" in error_message
+                and "http client error" in error_message.lower()
+            ):
                 logger.error(
                     message=(
                         f"{self.log_prefix}: Received 400 while accessing the "
@@ -1378,7 +1798,7 @@ class NetskopeClient:
     def _get_unique_incident_ids(self, data: List[Dict]):
         incident_ids_dict = defaultdict(list)
         for dlp_incident in data:
-            dlp_id = dlp_incident.get('dlp_incident_id')
+            dlp_id = dlp_incident.get("dlp_incident_id")
             if dlp_id:
                 incident_ids_dict[dlp_id].append(dlp_incident)
         return incident_ids_dict


### PR DESCRIPTION
# 1.7.0-hotfix (Requires minimum Cloud Exchange version 6.0.0)
## Changed
- Updated the pull retry mechanism with a unified in-pull exponential backoff engine, replacing the legacy @retry decorator for more reliable handling of transient failures. Retries are now strictly bounded by pull windows (or 1 hour for historical pulls).
- Added recovery for interrupted data streams (including automatic Dataexport resend support) while immediately failing only on authentication/permission errors (401/403).
